### PR TITLE
Fix timestamp format for non-US locales

### DIFF
--- a/src/helpers/getTimestamp.ts
+++ b/src/helpers/getTimestamp.ts
@@ -1,7 +1,7 @@
 import { convertTime } from '.';
 
 export const getTimestamp = (): string => {
-  const time = convertTime(new Date().toLocaleTimeString());
+  const time = convertTime(new Date().toLocaleTimeString('en-US', { hour12: true })) || '00:00:00';
   // const date = new Date().toLocaleDateString()
   const date = new Date().toLocaleDateString('default', { month: 'numeric', day: 'numeric' });
 


### PR DESCRIPTION
Bug: Undefined timestamp for non-US locales, toLocaleTimeString() returning 24h format on some computers.

Fix: Forcing the 12h timestamp format in src/helpers/getTimestamp.ts.